### PR TITLE
删去特选商鞅方升

### DIFF
--- a/assets/config/maa_pi_config.json
+++ b/assets/config/maa_pi_config.json
@@ -1,1 +1,56 @@
-{}
+{
+    "resource": "B 服",
+    "controller": {
+        "name": "安卓端"
+    },
+    "adb": {
+        "adb_path": "C:/Program Files/YXArkNights-12.0/shell/adb.exe",
+        "address": "127.0.0.1:16384",
+        "config": {
+            "extras": {
+                "mumu": {
+                    "enable": true,
+                    "index": 0,
+                    "path": "C:/Program Files/YXArkNights-12.0"
+                }
+            }
+        }
+    },
+    "task": [
+        {
+            "name": "研究学习",
+            "option": [],
+            "__vscKey": "9ce4351f-f229-4f21-ab51-13f83334de49"
+        },
+        {
+            "name": "研究学习",
+            "option": [],
+            "__vscKey": "f37c3ce9-6b2b-4d2a-a987-25cb93c7544c"
+        },
+        {
+            "name": "研究学习",
+            "option": [],
+            "__vscKey": "91c1e823-b4c1-4356-823d-ceb58003dd0c"
+        },
+        {
+            "name": "研究学习",
+            "option": [],
+            "__vscKey": "d881515a-502f-44b1-8ea1-b5451d4e42ad"
+        },
+        {
+            "name": "研究学习",
+            "option": [],
+            "__vscKey": "ea1dc47f-4a10-4075-95ca-b032a2aaf7c1"
+        },
+        {
+            "name": "研究学习",
+            "option": [],
+            "__vscKey": "2bb89ddd-7935-45e9-b22a-245d1c9c367b"
+        },
+        {
+            "name": "研究学习",
+            "option": [],
+            "__vscKey": "4ea62a52-f231-4e18-8fae-da34e04723ee"
+        }
+    ]
+}

--- a/assets/interface.json
+++ b/assets/interface.json
@@ -15,6 +15,10 @@
     ],
     "task": [
         {
+            "name": "待机",
+            "entry": "daiji"
+        },
+        {
             "name": "启动",
             "entry": "Start"
         },

--- a/assets/resource_picli/base/pipeline/11-research and lenrning  gold and silver repeat.json
+++ b/assets/resource_picli/base/pipeline/11-research and lenrning  gold and silver repeat.json
@@ -25,109 +25,7 @@
         "recognition": "TemplateMatch",
         "template": "Research2/choose_role.png",
         "action": "Click",
-        "next": [
-            "rlgr-change-tag-Assassin"
-        ]
-    },
-    "rlgr-change-tag-Assassin": {
-        "recognition": "TemplateMatch",
-        "template": "Research2/filter.png",
-        "roi": [
-            1197,
-            10,
-            61,
-            42
-        ],
-        "action": "Click",
-        "next": [
-            "rlgr-choose-tag-Assassin"
-        ]
-    },
-    "rlgr-choose-tag-Assassin": {
-        "recognition": "OCR",
-        "expected": "轻锐",
-        "roi": [
-            469,
-            207,
-            501,
-            60
-        ],
-        "action": "Click",
-        "next": [
-            "rlgr-ensure-tag"
-        ]
-    },
-    "rlgr-ensure-tag": {
-        "recognition": "OCR",
-        "expected": "确定",
-        "action": "Click",
-        "next": [
-            "rlgr-find-shangyang"
-        ],
-        "interrupt": [
-            "rlgr-swipe-page"
-        ]
-    },
-    "rlgr-swipe-page": {
-        "action": "Swipe",
-        "begin": [
-            780,
-            362,
-            0,
-            0
-        ],
-        "end": [
-            475,
-            362,
-            0,
-            0
-        ],
-        "duration": 1000,
-        "post_delay": 500
-    },
-    "rlgr-find-shangyang": {
-        "recognition": "OCR",
-        "expected": "商鞅方升",
-        "action": "Click",
-        "post_delay": 1000,
-        "next": [
-            "rlgr-change-tag"
-        ]
-    },
-    "rlgr-change-tag": {
-        "recognition": "TemplateMatch",
-        "template": "Research2/filter.png",
-        "roi": [
-            1197,
-            10,
-            61,
-            42
-        ],
-        "post_delay": 1000,
-        "action": "Click",
-        "next": [
-            "rlgr-choose-tag-2"
-        ]
-    },
-    "rlgr-choose-tag-2": {
-        "recognition": "OCR",
-        "expected": "全部",
-        "roi": [
-            469,
-            207,
-            501,
-            60
-        ],
-        "post_delay": 1000,
-        "action": "Click",
-        "next": [
-            "rlgr-ensure-tag-1"
-        ]
-    },
-    "rlgr-ensure-tag-1": {
-        "recognition": "OCR",
-        "expected": "确定",
-        "action": "Click",
+        "post_delay": 2000,
         "next": [
             "rlgr-choose-role-1"
         ]
@@ -136,7 +34,7 @@
         "action": "Click",
         "target": [
             554,
-            511,
+            191,
             1,
             1
         ],
@@ -146,8 +44,8 @@
     "rlgr-choose-role-2": {
         "action": "Click",
         "target": [
-            693,
-            191,
+            554,
+            511,
             1,
             1
         ],
@@ -155,6 +53,17 @@
         "next": "rlgr-choose-role-3"
     },
     "rlgr-choose-role-3": {
+        "action": "Click",
+        "target": [
+            693,
+            191,
+            1,
+            1
+        ],
+        "post_delay": 1000,
+        "next": "rlgr-choose-role-4"
+    },
+    "rlgr-choose-role-4": {
         "action": "Click",
         "target": [
             699,
@@ -230,7 +139,7 @@
             351,
             55
         ],
-        "post_wait_freezes": 500,
+        "post_wait_freezes": 1000,
         "action": "Click",
         "next": [
             "rlgr-rest-sure"
@@ -239,7 +148,7 @@
     "rlgr-rest-sure": {
         "recognition": "OCR",
         "expected": "确认",
-        "post_wait_freezes": 500,
+        "post_wait_freezes": 1000,
         "action": "Click",
         "next": [
             "rlgr-recognition"
@@ -255,7 +164,7 @@
             80
         ],
         "action": "Click",
-        "post_wait_freezes": 500,
+        "post_wait_freezes": 1000,
         "next": [
             "rlgr-fight-begin",
             "rlgr-recognition"
@@ -313,13 +222,7 @@
     },
     "rlgr-fight-begin-2": {
         "recognition": "TemplateMatch",
-        "template": "Research2\\begin_fight.png",
-        "roi": [
-            1012,
-            621,
-            268,
-            99
-        ],
+        "template": "Research2//begin_fight.png",
         "action": "Click",
         "next": [
             "rlgr-sure-fightwait",

--- a/assets/resource_picli/base/pipeline/daiji.json
+++ b/assets/resource_picli/base/pipeline/daiji.json
@@ -1,0 +1,15 @@
+{
+    "daiji": {
+        "action": "Click",
+        "target": [
+            1200,
+            630,
+            0,
+            0
+        ],
+        "post_delay": 500,
+        "next": [
+            "daiji"
+        ]
+    }
+}


### PR DESCRIPTION
由于官方的更新中，选择角色界面已经可以根据好感度排序，故而不再需要选择一个人人都有的商鞅方升来保证通关，只需要MWA使用者将最强的四位角色设为关心即可。